### PR TITLE
Updated R packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN echo 'install.packages(c( \
 "caret", \
 "modelr", \
 "lmerTest", \
-"lme4", \
 "pwr", \
 "BayesFactor", \
 "boot", \
@@ -44,13 +43,16 @@ RUN echo 'install.packages(c( \
 "sfsmisc", \
 "bookdown",\
 "ggfortify"), \
-  repos="http://cran.us.r-project.org", dependencies=TRUE)' > /tmp/packages.R && \
-  Rscript /tmp/packages.R
+  repos="http://cran.us.r-project.org", dependencies=TRUE)' > /tmp/packages.R
+
+# lme4 dropped repos https://cran.us.r-project.org
+
+RUN echo 'install.packages("lme4", dependencies=TRUE)' >> /tmp/packages.R && Rscript /tmp/packages.R
 
 # fiftystater was removed from CRAN so must be installed from the archive
 
 RUN echo 'install.packages("https://cran.r-project.org/src/contrib/Archive/fiftystater/fiftystater_1.0.1.tar.gz",\
-  repos=NULL,dependencies=TRUE)' > /tmp/packages2.R  && Rscript /tmp/packages2.R
+  repos=NULL,dependencies=TRUE)' > /tmp/packages2.R
 
 # BayesMed was removed from CRAN so must be installed from the archive
 RUN echo 'install.packages(c( \
@@ -58,9 +60,13 @@ RUN echo 'install.packages(c( \
 "QRM", \
 "polspline", \
 "MCMCpack"), \
-  repos="http://cran.us.r-project.org", dependencies=TRUE)' > /tmp/packages.R && \
-  Rscript /tmp/packages.R
+  repos="http://cran.us.r-project.org", dependencies=TRUE)' >> /tmp/packages2.R
+
 RUN echo 'install.packages("https://cran.r-project.org/src/contrib/Archive/BayesMed/BayesMed_1.0.1.tar.gz",\
-  repos=NULL,dependencies=TRUE)' > /tmp/packages2.R  && Rscript /tmp/packages2.R
+  repos=NULL,dependencies=TRUE)' >> /tmp/packages2.R
+
+# install lsmeans_2.27-62 from archive
+RUN echo 'install.packages("https://cran.r-project.org/src/contrib/Archive/lsmeans/lsmeans_2.27-62.tar.gz",\
+  repos=NULL,dependencies=TRUE)' >> /tmp/packages2.R  && Rscript /tmp/packages2.R
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN echo 'install.packages(c( \
 "DiagrammeR", \
 "caret", \
 "modelr", \
-"lmerTest", \
 "pwr", \
 "BayesFactor", \
 "boot", \
@@ -47,7 +46,11 @@ RUN echo 'install.packages(c( \
 
 # lme4 dropped repos https://cran.us.r-project.org
 
-RUN echo 'install.packages("lme4", dependencies=TRUE)' >> /tmp/packages.R && Rscript /tmp/packages.R
+RUN echo 'install.packages("lme4", dependencies=TRUE)' >> /tmp/packages.R
+
+# lmerTest repos updated to https://cran.rstudio.com
+
+RUN echo 'install.packages("lmerTest", repos = "https://cran.rstudio.com", dependencies = TRUE)' >> /tmp/packages.R && Rscript /tmp/packages.R
 
 # fiftystater was removed from CRAN so must be installed from the archive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN sudo apt-get dist-upgrade -y
 RUN sudo apt-get autoremove
 RUN apt-get install -y make git ssh
 RUN apt-get install  -y jags
-RUN apt-get install -y gsl-bin libgsl-dev libv8-3.14.5
+# RUN apt-get install -y gsl-bin libgsl-dev libv8-3.14.5
+RUN apt-get install -y gsl-bin libgsl-dev libnode-dev
 RUN apt-get install  -y libudunits2-0
 RUN apt-get install -y texlive-full
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,13 @@ RUN echo 'install.packages("https://cran.r-project.org/src/contrib/Archive/fifty
   repos=NULL,dependencies=TRUE)' > /tmp/packages2.R  && Rscript /tmp/packages2.R
 
 # BayesMed was removed from CRAN so must be installed from the archive
-
+RUN echo 'install.packages(c( \
+"R2jags", \
+"QRM", \
+"polspline", \
+"MCMCpack"), \
+  repos="http://cran.us.r-project.org", dependencies=TRUE)' > /tmp/packages.R && \
+  Rscript /tmp/packages.R
 RUN echo 'install.packages("https://cran.r-project.org/src/contrib/Archive/BayesMed/BayesMed_1.0.1.tar.gz",\
   repos=NULL,dependencies=TRUE)' > /tmp/packages2.R  && Rscript /tmp/packages2.R
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN echo 'install.packages(c( \
 "reshape2", \
 "NHANES", \
 "fivethirtyeight", \
+"gmodels", \
 "sfsmisc", \
 "bookdown",\
 "ggfortify"), \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN echo 'install.packages(c( \
 "pander", \
 "DiagrammeR", \
 "caret", \
-"BayesMed", \
 "modelr", \
 "lmerTest", \
 "lme4", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,9 @@ RUN echo 'install.packages(c( \
 RUN echo 'install.packages("https://cran.r-project.org/src/contrib/Archive/fiftystater/fiftystater_1.0.1.tar.gz",\
   repos=NULL,dependencies=TRUE)' > /tmp/packages2.R  && Rscript /tmp/packages2.R
 
+# BayesMed was removed from CRAN so must be installed from the archive
+
+RUN echo 'install.packages("https://cran.r-project.org/src/contrib/Archive/BayesMed/BayesMed_1.0.1.tar.gz",\
+  repos=NULL,dependencies=TRUE)' > /tmp/packages2.R  && Rscript /tmp/packages2.R
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
This pull request addressed compiling issues identified in PR #5. Dockerfile was updated to fixed issues for installing a few R packages.

Building the image took about an hour. An updated Docker image is available [here](https://hub.docker.com/repository/docker/kai2019/statsthinking21) for quick testing.